### PR TITLE
Fix Registry#getPendingMigrations() for case when direction is 'down'

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -37,9 +37,9 @@ Registry.prototype.putCompletedMigrations = function(migrations, cb) {
 Registry.prototype.getPendingMigrations = function(direction, cb) {
 	return this.get(function(data) {
 		if ('down' === direction) {
-			cb(data.available.slice(0, data.completed.length).reverse());
+			cb(data.completed.slice().reverse());
 		} else {
-			cb(data.available.slice(data.completed.length));
+			cb(data.available.slice());
 		}
 	});
 }

--- a/test/registry.js
+++ b/test/registry.js
@@ -71,16 +71,16 @@ describe('Registry', function() {
 	});
 
 	it('Should yield with list of pending migrations for down direction', function() {
-		registry.getPendingMigrations('up', function(migrations) {
-			migrations.should.have.members(notCompletedMigrations);
-			migrations.should.not.have.members(completedMigrations);
+		registry.getPendingMigrations('down', function(migrations) {
+			migrations.should.have.members(completedMigrations);
+			migrations.should.not.have.members(notCompletedMigrations);
 		});
 	});
 
 	it('Should yield with list of pending migrations for up direction', function() {
-		registry.getPendingMigrations('down', function(migrations) {
-			migrations.should.have.members(completedMigrations);
-			migrations.should.not.have.members(notCompletedMigrations);
+		registry.getPendingMigrations('up', function(migrations) {
+			migrations.should.have.members(availableMigrations);
+			migrations.should.not.have.members(completedMigrations);
 		});
 	});
 


### PR DESCRIPTION
Available migrations collection is not quite right for this case, since person can add migration which was not run yet, so reversing it would cause issues. Instead use completed migrations collection to reverse only existing DB stuff only.
